### PR TITLE
Add goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
       - "v*"
 
 jobs:
-  build:
-    name: Build and release
+  release:
+    name: Release
     runs-on: ubuntu-latest
 
     permissions:
@@ -16,28 +16,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
 
-      - name: Build binaries
-        run: |
-          VERSION=${GITHUB_REF_NAME}
-          LDFLAGS="-X main.version=${VERSION}"
-          mkdir -p dist
-          GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/kronk-windows-amd64.exe .
-          GOOS=linux   GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/kronk-linux-amd64 .
-          GOOS=darwin  GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o dist/kronk-darwin-arm64 .
-          GOOS=darwin  GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/kronk-darwin-amd64 .
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          files: |
-            dist/kronk-windows-amd64.exe
-            dist/kronk-linux-amd64
-            dist/kronk-darwin-arm64
-            dist/kronk-darwin-amd64
-          generate_release_notes: true
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,60 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -X main.version={{.Version}}
+
+archives:
+  - formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+release:
+  github:
+    owner: janpgu
+    name: kronk
+  generate_release_notes: true
+
+brews:
+  - name: kronk
+    repository:
+      owner: janpgu
+      name: homebrew-kronk
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: "https://github.com/janpgu/kronk"
+    description: "Pull the lever. Zero-infrastructure job scheduler with history, retries, and natural language scheduling."
+    license: "MIT"
+    install: |
+      bin.install "kronk"
+    test: |
+      system "#{bin}/kronk", "version"
+
+scoops:
+  - name: kronk
+    repository:
+      owner: janpgu
+      name: scoop-kronk
+      token: "{{ .Env.SCOOP_BUCKET_TOKEN }}"
+    homepage: "https://github.com/janpgu/kronk"
+    description: "Pull the lever. Zero-infrastructure job scheduler with history, retries, and natural language scheduling."
+    license: "MIT"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,6 +46,7 @@ brews:
     license: "MIT"
     install: |
       bin.install "kronk"
+      # TODO: add `system "#{bin}/kronk", "setup"` once kronk setup is implemented
     test: |
       system "#{bin}/kronk", "version"
 

--- a/README.md
+++ b/README.md
@@ -22,21 +22,34 @@ It's for people who need scheduled tasks on a machine they control, like a home 
 
 ## Install
 
-**Linux / macOS** (one line):
+**macOS / Linux via Homebrew:**
+
+```sh
+brew install janpgu/kronk/kronk
+```
+
+**Windows via Scoop:**
+
+```powershell
+scoop bucket add kronk https://github.com/janpgu/scoop-kronk
+scoop install kronk
+```
+
+Then run `kronk doctor` to complete setup.
+
+**Or via the install scripts:**
+
+Linux / macOS:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/janpgu/kronk/main/install.sh | sh
 ```
 
-Installs the binary to `/usr/local/bin` and adds the crontab entry automatically.
-
-**Windows** (one line in PowerShell):
+Windows (PowerShell):
 
 ```powershell
 irm https://raw.githubusercontent.com/janpgu/kronk/main/install.ps1 | iex
 ```
-
-Installs the binary to `~/bin`, adds it to PATH, and registers a Task Scheduler task that runs every minute, including on battery.
 
 **Or build from source:**
 


### PR DESCRIPTION
Replaces the manual build script in `release.yml` with GoReleaser.

- Builds for all 6 platform/arch combinations (windows, linux, darwin × amd64, arm64)
- Generates `checksums.txt` automatically
- Creates the GitHub release with notes
- Auto-updates `janpgu/homebrew-kronk` and `janpgu/scoop-kronk` on every tag push