### PR TITLE
Add kronk setup

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ brews:
     license: "MIT"
     install: |
       bin.install "kronk"
-      # TODO: add `system "#{bin}/kronk", "setup"` once kronk setup is implemented
+      system "#{bin}/kronk", "setup"
     test: |
       system "#{bin}/kronk", "version"
 
@@ -59,3 +59,5 @@ scoops:
     homepage: "https://github.com/janpgu/kronk"
     description: "Pull the lever. Zero-infrastructure job scheduler with history, retries, and natural language scheduling."
     license: "MIT"
+    post_install:
+      - "kronk setup"

--- a/README.md
+++ b/README.md
@@ -35,21 +35,7 @@ scoop bucket add kronk https://github.com/janpgu/scoop-kronk
 scoop install kronk
 ```
 
-Then run `kronk doctor` to complete setup.
-
-**Or via the install scripts:**
-
-Linux / macOS:
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/janpgu/kronk/main/install.sh | sh
-```
-
-Windows (PowerShell):
-
-```powershell
-irm https://raw.githubusercontent.com/janpgu/kronk/main/install.ps1 | iex
-```
+Both automatically run `kronk setup` to register the system scheduler — no extra steps needed.
 
 **Or build from source:**
 
@@ -57,7 +43,7 @@ irm https://raw.githubusercontent.com/janpgu/kronk/main/install.ps1 | iex
 go install github.com/janpgu/kronk@latest
 ```
 
-Then run `kronk doctor` to complete setup.
+Then run `kronk setup` to register with the system scheduler.
 
 Requires Go 1.22+. No C compiler needed as the SQLite driver is pure Go.
 
@@ -100,6 +86,7 @@ kronk trigger backup
 | `kronk remove <name>` | Remove a job and its history |
 | `kronk prune [--days N]` | Delete run history older than N days (default 30) |
 | `kronk edit` | Edit all jobs in $EDITOR |
+| `kronk setup` | Register kronk with the system scheduler |
 | `kronk doctor` | Print config and setup instructions |
 | `kronk version` | Print the kronk version |
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -77,32 +77,17 @@ func checkDBFile(dbPath string) {
 
 // printSetupInstructions prints the correct scheduler setup for the current OS.
 func printSetupInstructions(binary string) {
+	fmt.Println("  Run the following command to register kronk with your system scheduler:")
+	fmt.Println()
+	fmt.Printf("  %s setup\n", binary)
+	fmt.Println()
+
 	switch runtime.GOOS {
 	case "windows":
-		fmt.Println("  The easiest way to set up kronk is with the install script:")
-		fmt.Println()
-		fmt.Println("  irm https://raw.githubusercontent.com/janpgu/kronk/main/install.ps1 | iex")
-		fmt.Println()
-		fmt.Println("  Or manually register with Task Scheduler:")
-		fmt.Println()
-		fmt.Printf("  schtasks /create /tn \"kronk\" /tr \"wscript.exe //B %%USERPROFILE%%\\bin\\kronk-tick.vbs\" /sc MINUTE /mo 1\n")
-
-	case "darwin":
-		fmt.Println("  The easiest way to set up kronk is with the install script:")
-		fmt.Println()
-		fmt.Println("  curl -fsSL https://raw.githubusercontent.com/janpgu/kronk/main/install.sh | sh")
-		fmt.Println()
-		fmt.Println("  Or manually add to crontab (crontab -e):")
-		fmt.Println()
-		fmt.Printf("  * * * * * %s tick\n", binary)
-
+		fmt.Println("  This registers a Task Scheduler task that runs kronk every minute,")
+		fmt.Println("  including on battery.")
 	default:
-		fmt.Println("  The easiest way to set up kronk is with the install script:")
-		fmt.Println()
-		fmt.Println("  curl -fsSL https://raw.githubusercontent.com/janpgu/kronk/main/install.sh | sh")
-		fmt.Println()
-		fmt.Println("  Or manually add to crontab (crontab -e):")
-		fmt.Println()
+		fmt.Printf("  This adds the following crontab entry:\n")
 		fmt.Printf("  * * * * * %s tick\n", binary)
 	}
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -87,7 +87,8 @@ func setupWindows(binary string) error {
 	ui.PrintSuccess(fmt.Sprintf("Silent launcher written: %s", vbsPath))
 
 	// Build the Task Scheduler XML definition.
-	taskXML := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-16"?>
+	// Note: no encoding declaration — schtasks accepts UTF-8 without it.
+	taskXML := fmt.Sprintf(`<?xml version="1.0"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
     <Description>kronk job scheduler tick</Description>

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/janpgu/kronk/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var setupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Register kronk with the system scheduler (cron or Task Scheduler)",
+	Long: `Sets up the system scheduler so that kronk runs automatically every minute.
+
+On Linux and macOS, adds a crontab entry.
+On Windows, writes a silent VBScript launcher and registers a Task Scheduler task.
+
+Safe to run multiple times — existing entries are updated, not duplicated.`,
+	Args: cobra.NoArgs,
+	RunE: runSetup,
+}
+
+func init() {
+	rootCmd.AddCommand(setupCmd)
+}
+
+func runSetup(cmd *cobra.Command, args []string) error {
+	binary, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("could not determine binary path: %w", err)
+	}
+
+	switch runtime.GOOS {
+	case "windows":
+		return setupWindows(binary)
+	default:
+		return setupUnix(binary)
+	}
+}
+
+// setupUnix adds a crontab entry for `kronk tick` if one is not already present.
+func setupUnix(binary string) error {
+	cronLine := fmt.Sprintf("* * * * * %s tick", binary)
+
+	// Read existing crontab.
+	out, err := exec.Command("crontab", "-l").Output()
+	existing := ""
+	if err == nil {
+		existing = string(out)
+	}
+	// A non-zero exit from `crontab -l` just means no crontab exists yet — not an error.
+
+	if strings.Contains(existing, binary+" tick") {
+		ui.PrintSuccess("Crontab entry already present — nothing to do.")
+		return nil
+	}
+
+	// Append the new entry and install.
+	updated := strings.TrimRight(existing, "\n") + "\n" + cronLine + "\n"
+	pipe := exec.Command("crontab", "-")
+	pipe.Stdin = strings.NewReader(updated)
+	pipe.Stdout = os.Stdout
+	pipe.Stderr = os.Stderr
+	if err := pipe.Run(); err != nil {
+		return fmt.Errorf("could not update crontab: %w", err)
+	}
+
+	ui.PrintSuccess(fmt.Sprintf("Crontab entry added: %s", cronLine))
+	return nil
+}
+
+// setupWindows writes a silent VBScript launcher and registers a Task Scheduler task.
+func setupWindows(binary string) error {
+	installDir := filepath.Dir(binary)
+	vbsPath := filepath.Join(installDir, "kronk-tick.vbs")
+
+	// Write the VBScript wrapper that launches kronk tick with no console window.
+	vbsContent := fmt.Sprintf(`CreateObject("WScript.Shell").Run "%s tick", 0, False`, binary)
+	if err := os.WriteFile(vbsPath, []byte(vbsContent), 0644); err != nil {
+		return fmt.Errorf("could not write launcher script: %w", err)
+	}
+	ui.PrintSuccess(fmt.Sprintf("Silent launcher written: %s", vbsPath))
+
+	// Build the Task Scheduler XML definition.
+	taskXML := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>kronk job scheduler tick</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <TimeTrigger>
+      <Repetition>
+        <Interval>PT1M</Interval>
+        <StopAtDurationEnd>false</StopAtDurationEnd>
+      </Repetition>
+      <StartBoundary>2000-01-01T00:00:00</StartBoundary>
+      <Enabled>true</Enabled>
+    </TimeTrigger>
+  </Triggers>
+  <Settings>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <ExecutionTimeLimit>PT5M</ExecutionTimeLimit>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <Enabled>true</Enabled>
+  </Settings>
+  <Actions>
+    <Exec>
+      <Command>wscript.exe</Command>
+      <Arguments>//B "%s"</Arguments>
+    </Exec>
+  </Actions>
+</Task>`, vbsPath)
+
+	// Write XML to a temp file — schtasks requires a file path.
+	xmlPath := filepath.Join(os.TempDir(), "kronk-task.xml")
+	if err := os.WriteFile(xmlPath, []byte(taskXML), 0644); err != nil {
+		return fmt.Errorf("could not write task XML: %w", err)
+	}
+	defer os.Remove(xmlPath)
+
+	// Remove existing task silently before re-creating.
+	exec.Command("schtasks", "/delete", "/tn", "kronk", "/f").Run() //nolint:errcheck
+
+	// Register the task.
+	out, err := exec.Command("schtasks", "/create", "/tn", "kronk", "/xml", xmlPath, "/f").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("could not register Task Scheduler task: %s", strings.TrimSpace(string(out)))
+	}
+
+	ui.PrintSuccess("Task Scheduler task 'kronk' registered (runs every minute, including on battery)")
+	return nil
+}


### PR DESCRIPTION
Adds `kronk setup`, which registers kronk with the system scheduler so every install path gets the same out-of-the-box experience.

- On Linux/macOS: adds a crontab entry (`* * * * * /path/to/kronk tick`)
- On Windows: writes a silent VBScript launcher and registers a Task Scheduler task (runs every minute, including on battery)
- Safe to run multiple times as existing entries are updated, not duplicated
- Homebrew formula and Scoop manifest now call `kronk setup` automatically post-install
- `kronk doctor` updated to point users at `kronk setup` instead of the install scripts
- README install section updated to reflect the new flow