### PR TITLE
add per-job timeout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ kronk trigger backup
 
 | Command | Description |
 |---|---|
-| `kronk add <cmd> --name <n> --schedule <s>` | Add a new job |
+| `kronk add <cmd> --name <n> --schedule <s> [--retries N] [--timeout N]` | Add a new job |
 | `kronk status` | Show all jobs and their next run time |
 | `kronk show <name>` | Show all details for a single job |
 | `kronk pause <name>` | Pause a job without removing it |
@@ -130,6 +130,16 @@ kronk add "python flaky.py" --name flaky --schedule "every hour" --retries 3
 ```
 
 On failure, kronk retries with exponential backoff: 2s, 4s, 8s after each attempt. After all retries are exhausted the job is marked `failed` and won't run again until you reset it with `kronk edit`.
+
+---
+
+## Timeouts
+
+```sh
+kronk add "python long_export.py" --name export --schedule "every night" --timeout 300
+```
+
+`--timeout` is in seconds. If the process is still running after that many seconds, kronk kills it and records the run as failed with `killed: exceeded timeout of Ns` in stderr. A timeout of `0` (the default) means no limit.
 
 ---
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -22,12 +22,14 @@ var (
 	addName     string
 	addSchedule string
 	addRetries  int
+	addTimeout  int
 )
 
 func init() {
 	addCmd.Flags().StringVar(&addName, "name", "", "unique name for the job (required)")
 	addCmd.Flags().StringVar(&addSchedule, "schedule", "", "when to run, e.g. \"every night\" (required)")
 	addCmd.Flags().IntVar(&addRetries, "retries", 0, "number of times to retry on failure")
+	addCmd.Flags().IntVar(&addTimeout, "timeout", 0, "kill the job after this many seconds (0 = no timeout)")
 
 	_ = addCmd.MarkFlagRequired("name")
 	_ = addCmd.MarkFlagRequired("schedule")
@@ -57,12 +59,13 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	defer database.Close()
 
 	j := &job.Job{
-		Name:         addName,
-		Command:      command,
-		ScheduleRaw:  addSchedule,
-		ScheduleCron: cronExpr,
-		MaxRetries:   addRetries,
-		NextRunAt:    &nextRun,
+		Name:           addName,
+		Command:        command,
+		ScheduleRaw:    addSchedule,
+		ScheduleCron:   cronExpr,
+		MaxRetries:     addRetries,
+		TimeoutSeconds: addTimeout,
+		NextRunAt:      &nextRun,
 	}
 
 	if _, err := db.AddJob(database, j); err != nil {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -87,6 +87,33 @@ func TestRunAdd(t *testing.T) {
 	}
 }
 
+func TestRunAdd_WithTimeout(t *testing.T) {
+	setupTestDB(t)
+
+	addName = "timed"
+	addSchedule = "every minute"
+	addRetries = 0
+	addTimeout = 30
+	if err := runAdd(nil, []string{"echo timed"}); err != nil {
+		t.Fatalf("runAdd() unexpected error: %v", err)
+	}
+	addTimeout = 0 // reset
+
+	database, err := db.Open(cfg.DBPath)
+	if err != nil {
+		t.Fatalf("db.Open() unexpected error: %v", err)
+	}
+	defer database.Close()
+
+	got, err := db.GetJob(database, "timed")
+	if err != nil {
+		t.Fatalf("db.GetJob() unexpected error: %v", err)
+	}
+	if got.TimeoutSeconds != 30 {
+		t.Errorf("runAdd() TimeoutSeconds = %d, want 30", got.TimeoutSeconds)
+	}
+}
+
 func TestRunAdd_InvalidSchedule(t *testing.T) {
 	setupTestDB(t)
 

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -48,14 +48,15 @@ func runEdit(cmd *cobra.Command, args []string) error {
 	defer os.Remove(tmpPath)
 
 	fmt.Fprintln(tmpFile, "# kronk job editor")
-	fmt.Fprintln(tmpFile, "# Format: name | schedule | retries | command")
+	fmt.Fprintln(tmpFile, "# Format: name | schedule | retries | timeout | command")
 	fmt.Fprintln(tmpFile, "# - Edit existing lines to update jobs")
 	fmt.Fprintln(tmpFile, "# - Add new lines to create jobs")
 	fmt.Fprintln(tmpFile, "# - Delete lines to remove jobs (you will be prompted)")
 	fmt.Fprintln(tmpFile, "# - Lines starting with # are ignored")
+	fmt.Fprintln(tmpFile, "# - timeout is in seconds, 0 means no timeout")
 	fmt.Fprintln(tmpFile)
 	for _, j := range jobs {
-		fmt.Fprintf(tmpFile, "%s | %s | %d | %s\n", j.Name, j.ScheduleRaw, j.MaxRetries, j.Command)
+		fmt.Fprintf(tmpFile, "%s | %s | %d | %d | %s\n", j.Name, j.ScheduleRaw, j.MaxRetries, j.TimeoutSeconds, j.Command)
 	}
 	tmpFile.Close()
 
@@ -164,12 +165,13 @@ func runEdit(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		j := &job.Job{
-			Name:         e.name,
-			Command:      e.command,
-			ScheduleRaw:  e.scheduleRaw,
-			ScheduleCron: cronExpr,
-			MaxRetries:   e.retries,
-			NextRunAt:    &nextRun,
+			Name:           e.name,
+			Command:        e.command,
+			ScheduleRaw:    e.scheduleRaw,
+			ScheduleCron:   cronExpr,
+			MaxRetries:     e.retries,
+			TimeoutSeconds: e.timeout,
+			NextRunAt:      &nextRun,
 		}
 		if _, err := db.AddJob(database, j); err != nil {
 			return err
@@ -187,6 +189,7 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		j.ScheduleRaw = e.scheduleRaw
 		j.ScheduleCron = cronExpr
 		j.MaxRetries = e.retries
+		j.TimeoutSeconds = e.timeout
 		j.NextRunAt = &nextRun
 		if err := db.UpdateJob(database, j); err != nil {
 			return err
@@ -208,6 +211,7 @@ type editedJob struct {
 	name        string
 	scheduleRaw string
 	retries     int
+	timeout     int
 	command     string
 }
 
@@ -228,14 +232,15 @@ func parseEditFile(path string) ([]editedJob, error) {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		parts := strings.SplitN(line, "|", 4)
-		if len(parts) != 4 {
-			return nil, fmt.Errorf("line %d: expected format 'name | schedule | retries | command', got: %q", lineNum, line)
+		parts := strings.SplitN(line, "|", 5)
+		if len(parts) != 5 {
+			return nil, fmt.Errorf("line %d: expected format 'name | schedule | retries | timeout | command', got: %q", lineNum, line)
 		}
 		name := strings.TrimSpace(parts[0])
 		scheduleRaw := strings.TrimSpace(parts[1])
 		retriesStr := strings.TrimSpace(parts[2])
-		command := strings.TrimSpace(parts[3])
+		timeoutStr := strings.TrimSpace(parts[3])
+		command := strings.TrimSpace(parts[4])
 
 		if name == "" || scheduleRaw == "" || command == "" {
 			return nil, fmt.Errorf("line %d: name, schedule, and command must not be empty", lineNum)
@@ -246,7 +251,12 @@ func parseEditFile(path string) ([]editedJob, error) {
 			return nil, fmt.Errorf("line %d: retries must be a number, got %q", lineNum, retriesStr)
 		}
 
-		jobs = append(jobs, editedJob{name, scheduleRaw, retries, command})
+		timeout, err := strconv.Atoi(timeoutStr)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: timeout must be a number, got %q", lineNum, timeoutStr)
+		}
+
+		jobs = append(jobs, editedJob{name, scheduleRaw, retries, timeout, command})
 	}
 	return jobs, scanner.Err()
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -43,6 +43,12 @@ func runShow(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  %s  %s\n", label("Status:  "), ui.StatusStyle(string(j.Status)))
 	fmt.Printf("  %s  %d\n", label("Retries: "), j.MaxRetries)
 
+	if j.TimeoutSeconds > 0 {
+		fmt.Printf("  %s  %ds\n", label("Timeout: "), j.TimeoutSeconds)
+	} else {
+		fmt.Printf("  %s  %s\n", label("Timeout: "), ui.MutedStyle.Render("none"))
+	}
+
 	if j.NextRunAt != nil {
 		fmt.Printf("  %s  %s\n", label("Next Run:"), j.NextRunAt.Format("Mon 2 Jan 15:04"))
 	} else {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/janpgu/kronk/internal/job"
@@ -33,22 +34,25 @@ func Open(path string) (*sql.DB, error) {
 	return db, nil
 }
 
-// Migrate ensures all required tables exist. Safe to call on every startup —
-// CREATE TABLE IF NOT EXISTS is idempotent and never destroys existing data.
+// Migrate ensures all required tables and columns exist. Safe to call on every
+// startup — CREATE TABLE IF NOT EXISTS is idempotent. New columns are added via
+// ALTER TABLE, which is also safe to run repeatedly (errors for existing columns
+// are silently ignored).
 func Migrate(db *sql.DB) error {
 	_, err := db.Exec(`
 		CREATE TABLE IF NOT EXISTS jobs (
-			id            INTEGER PRIMARY KEY,
-			name          TEXT UNIQUE NOT NULL,
-			command       TEXT NOT NULL,
-			schedule_raw  TEXT NOT NULL,
-			schedule_cron TEXT NOT NULL,
-			max_retries   INTEGER DEFAULT 0,
-			status        TEXT DEFAULT 'active',
-			created_at    DATETIME,
-			updated_at    DATETIME,
-			last_run_at   DATETIME,
-			next_run_at   DATETIME
+			id               INTEGER PRIMARY KEY,
+			name             TEXT UNIQUE NOT NULL,
+			command          TEXT NOT NULL,
+			schedule_raw     TEXT NOT NULL,
+			schedule_cron    TEXT NOT NULL,
+			max_retries      INTEGER DEFAULT 0,
+			timeout_seconds  INTEGER DEFAULT 0,
+			status           TEXT DEFAULT 'active',
+			created_at       DATETIME,
+			updated_at       DATETIME,
+			last_run_at      DATETIME,
+			next_run_at      DATETIME
 		);
 
 		CREATE TABLE IF NOT EXISTS runs (
@@ -65,6 +69,15 @@ func Migrate(db *sql.DB) error {
 	if err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}
+
+	// Add timeout_seconds to existing databases that predate this column.
+	// SQLite returns "duplicate column name" if it already exists — ignore that.
+	if _, err := db.Exec(`ALTER TABLE jobs ADD COLUMN timeout_seconds INTEGER DEFAULT 0`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name") {
+			return fmt.Errorf("migration failed: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -72,9 +85,9 @@ func Migrate(db *sql.DB) error {
 func AddJob(db *sql.DB, j *job.Job) (int64, error) {
 	now := time.Now()
 	result, err := db.Exec(`
-		INSERT INTO jobs (name, command, schedule_raw, schedule_cron, max_retries, status, created_at, updated_at, next_run_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		j.Name, j.Command, j.ScheduleRaw, j.ScheduleCron, j.MaxRetries, job.StatusActive, now, now, j.NextRunAt,
+		INSERT INTO jobs (name, command, schedule_raw, schedule_cron, max_retries, timeout_seconds, status, created_at, updated_at, next_run_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		j.Name, j.Command, j.ScheduleRaw, j.ScheduleCron, j.MaxRetries, j.TimeoutSeconds, job.StatusActive, now, now, j.NextRunAt,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("could not add job %q: %w", j.Name, err)
@@ -143,16 +156,17 @@ func GetDueJobs(db *sql.DB) ([]*job.Job, error) {
 func UpdateJob(db *sql.DB, j *job.Job) error {
 	_, err := db.Exec(`
 		UPDATE jobs SET
-			command       = ?,
-			schedule_raw  = ?,
-			schedule_cron = ?,
-			max_retries   = ?,
-			status        = ?,
-			updated_at    = ?,
-			last_run_at   = ?,
-			next_run_at   = ?
+			command          = ?,
+			schedule_raw     = ?,
+			schedule_cron    = ?,
+			max_retries      = ?,
+			timeout_seconds  = ?,
+			status           = ?,
+			updated_at       = ?,
+			last_run_at      = ?,
+			next_run_at      = ?
 		WHERE id = ?`,
-		j.Command, j.ScheduleRaw, j.ScheduleCron, j.MaxRetries,
+		j.Command, j.ScheduleRaw, j.ScheduleCron, j.MaxRetries, j.TimeoutSeconds,
 		j.Status, time.Now(), j.LastRunAt, j.NextRunAt, j.ID,
 	)
 	if err != nil {
@@ -348,7 +362,7 @@ func scanJob(s scanner) (*job.Job, error) {
 	err := s.Scan(
 		&j.ID, &j.Name, &j.Command,
 		&j.ScheduleRaw, &j.ScheduleCron,
-		&j.MaxRetries, &status,
+		&j.MaxRetries, &j.TimeoutSeconds, &status,
 		&j.CreatedAt, &j.UpdatedAt,
 		&j.LastRunAt, &j.NextRunAt,
 	)

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -21,17 +21,18 @@ const (
 
 // Job represents a scheduled task stored in the jobs table.
 type Job struct {
-	ID          int64
-	Name        string
-	Command     string
-	ScheduleRaw string    // human-readable input, e.g. "every night"
-	ScheduleCron string   // resolved cron expression, e.g. "0 2 * * *"
-	MaxRetries  int
-	Status      Status
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	LastRunAt   *time.Time // nil if never run
-	NextRunAt   *time.Time // nil if not scheduled
+	ID             int64
+	Name           string
+	Command        string
+	ScheduleRaw    string    // human-readable input, e.g. "every night"
+	ScheduleCron   string    // resolved cron expression, e.g. "0 2 * * *"
+	MaxRetries     int
+	TimeoutSeconds int       // 0 means no timeout
+	Status         Status
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	LastRunAt      *time.Time // nil if never run
+	NextRunAt      *time.Time // nil if not scheduled
 }
 
 // Run represents a single execution of a job, stored in the runs table.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -3,6 +3,7 @@ package worker
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"fmt"
 	"math"
@@ -49,7 +50,7 @@ func Execute(database *sql.DB, j *job.Job, verbose bool) error {
 	}
 
 	// Execute the command as a subprocess.
-	stdout, stderr, exitCode := runCommand(j.Command)
+	stdout, stderr, exitCode := runCommand(j.Command, j.TimeoutSeconds)
 	now := time.Now()
 	run.FinishedAt = &now
 	run.ExitCode = &exitCode
@@ -99,14 +100,22 @@ func Execute(database *sql.DB, j *job.Job, verbose bool) error {
 
 // runCommand executes a shell command and returns stdout, stderr, and exit code.
 // Uses "sh -c" on Unix and "cmd /C" on Windows.
-func runCommand(command string) (stdout, stderr string, exitCode int) {
+// If timeoutSeconds > 0, the process is killed after that many seconds.
+func runCommand(command string, timeoutSeconds int) (stdout, stderr string, exitCode int) {
 	var stdoutBuf, stderrBuf bytes.Buffer
+
+	ctx := context.Background()
+	if timeoutSeconds > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
+		defer cancel()
+	}
 
 	var cmd *exec.Cmd
 	if runtime.GOOS == "windows" {
-		cmd = exec.Command("cmd", "/C", command)
+		cmd = exec.CommandContext(ctx, "cmd", "/C", command)
 	} else {
-		cmd = exec.Command("sh", "-c", command)
+		cmd = exec.CommandContext(ctx, "sh", "-c", command)
 	}
 
 	cmd.Stdout = &stdoutBuf
@@ -118,6 +127,9 @@ func runCommand(command string) (stdout, stderr string, exitCode int) {
 	stderr = strings.ReplaceAll(stderrBuf.String(), "\r\n", "\n")
 
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return stdout, fmt.Sprintf("killed: exceeded timeout of %ds", timeoutSeconds), 1
+		}
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return stdout, stderr, exitErr.ExitCode()
 		}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -2,6 +2,8 @@ package worker
 
 import (
 	"database/sql"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -157,6 +159,37 @@ func TestExecute_ConcurrencyGuard(t *testing.T) {
 	}
 	if len(runs) != 1 {
 		t.Errorf("Execute() created %d runs, want 1 (concurrency guard should skip)", len(runs))
+	}
+}
+
+func TestExecute_Timeout(t *testing.T) {
+	database := openTestDB(t)
+
+	sleepCmd := "sleep 5"
+	if runtime.GOOS == "windows" {
+		sleepCmd = "ping -n 6 127.0.0.1 > NUL"
+	}
+
+	j := sampleJob("slow", sleepCmd)
+	j.TimeoutSeconds = 1
+	j = addJob(t, database, j)
+
+	if err := Execute(database, j, false); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	runs, err := db.GetRunsForJob(database, j.ID, 1)
+	if err != nil {
+		t.Fatalf("GetRunsForJob() unexpected error: %v", err)
+	}
+	if len(runs) == 0 {
+		t.Fatal("GetRunsForJob() = 0 runs, want 1")
+	}
+	if runs[0].ExitCode == nil || *runs[0].ExitCode == 0 {
+		t.Errorf("run ExitCode = %v, want non-zero (timeout kill)", runs[0].ExitCode)
+	}
+	if !strings.Contains(runs[0].Stderr, "killed") {
+		t.Errorf("run Stderr = %q, want it to contain %q", runs[0].Stderr, "killed")
 	}
 }
 


### PR DESCRIPTION
- New `--timeout <seconds>` flag on `kronk add` and `kronk edit`
- Jobs killed after N seconds; run recorded as failed with "killed: exceeded timeout" in stderr
- 0 means no timeout (default, backward-compatible)
- `timeout_seconds` column added via idempotent `ALTER TABLE` migration and thus no breaking changes to existing DBs